### PR TITLE
Disable SSL verification and update user element selection

### DIFF
--- a/get-tagged-photos.py
+++ b/get-tagged-photos.py
@@ -45,7 +45,7 @@ def index_photos(username, password):
     while True:
         time.sleep(main_wait)
         try:
-            user = wait.until(EC.presence_of_element_located((By.XPATH, '//*[@id="fbPhotoSnowliftAuthorName"]/a')))
+            user = wait.until(EC.presence_of_element_located((By.XPATH, '//*[@id="fbPhotoSnowliftAuthorName"]//a')))
             media_url = wait.until(EC.presence_of_element_located((By.XPATH, "//img[@class='spotlight']"))).get_attribute('src')
             is_video = "showVideo" in driver.find_element_by_css_selector(".stageWrapper").get_attribute("class")
         except selenium.common.exceptions.StaleElementReferenceException:

--- a/get-tagged-photos.py
+++ b/get-tagged-photos.py
@@ -1,4 +1,4 @@
-import argparse, sys, os, time, wget, json, piexif
+import argparse, sys, os, time, wget, json, piexif, ssl
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
@@ -95,6 +95,7 @@ def index_photos(username, password):
         f.close()
 
 def download_photos():
+    ssl._create_default_https_context = ssl._create_unverified_context
     #Prep the download folder
     folder = 'photos/'
     if not os.path.exists(folder):


### PR DESCRIPTION
@jcontini  Fixes for the following two issues I noticed:
• https://github.com/jcontini/fb-photo-downloader/commit/25fb8f580f230abcc1f2dce62f5efa2e22d6e3ee - Image downloads were throwing the following error - `ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:833)`
• https://github.com/jcontini/fb-photo-downloader/commit/a89fe02de50518305b0da95a30483a91e25622e7 - User element is not always a direct child of `#fbPhotoSnowliftAuthorName`. I saw this where posts were imported from third parties such as Wordpress.