### PR TITLE
Add: more robust navigation to "tagged photos page"

### DIFF
--- a/get-tagged-photos.py
+++ b/get-tagged-photos.py
@@ -32,8 +32,13 @@ def index_photos(username, password):
     driver.find_element_by_id("loginbutton").click()
 
     #Nav to photos I'm tagged in page
+    print('-' * 20 + '\nNavigating to profile view of user tagged photos...')
+    prof_btn_xpath = '//a[@title="Profile"]'
+    wait.until(EC.presence_of_element_located((By.XPATH, prof_btn_xpath)))
+    profile_path = driver.find_element(By.XPATH, prof_btn_xpath).get_attribute('href')
+    driver.get(profile_path.rstrip('/') + '/photos')
+
     print("-"*20 + "\nScanning Photos...")
-    driver.find_element_by_id("navItem_2305272732").click()
     wait.until(EC.presence_of_element_located((By.CLASS_NAME, "uiMediaThumbImg")))
     driver.find_elements_by_css_selector(".uiMediaThumbImg")[0].click()
     time.sleep(2)


### PR DESCRIPTION
I ran into some issues getting the `navItem_2305272732` to work and found a bit more robust method using the href from the profile button in the navbar to view photos the user is tagged in.

This would be an alternative to the 2nd chunk of #2 ([lines 35-39](https://github.com/jcontini/fb-photo-downloader/pull/2/files#diff-6fb9f1d98aa8ee4e217c3c001f7558a7R35))